### PR TITLE
fix(api): change /admin/file/update method from POST to PATCH

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -78,7 +78,7 @@ export class FileService {
   }
 
   static async updateFile(data: FileEditForm): Promise<ApiResponse> {
-    return api.post('/admin/file/update', data)
+    return api.patch('/admin/file/update', data)
   }
 
   static async deleteAdminFile(id: number): Promise<ApiResponse> {


### PR DESCRIPTION
## 变更描述
- **问题**：前端调用 `/admin/file/update` 接口时使用了 `POST` 方法，而后端实际要求使用 `PATCH` 方法。
- **修复**：将前端所有调用 `/admin/file/update` 接口的请求方法从 `POST` 修改为 `PATCH`。

## 修改范围
- 修改了文件：`\src\services\index.ts`
- 影响的功能：文件配置更新功能
- 
- 相关 Issue：Fixes https://github.com/vastsa/FileCodeBox/issues/420