### PR TITLE
fix: vastsa/FileCodeBox#453中的http访问浏览器卡主问题

### DIFF
--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -108,7 +108,7 @@ function fallbackCopyTextToClipboard(command: string) {
     if (document.hasFocus() && navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(command)
     } else {
-      fallbackCopyTextToClipboard(command)
+      console.error('回退复制操作失败')
     }
   } catch (err) {
     console.error('回退复制操作失败：', err)


### PR DESCRIPTION
在vastsa/FileCodeBox#453中讨论，有出现Windows系统，http访问点击复制wget命令浏览器卡主的问题。取消无线递归调用逻辑。