### PR TITLE
fix: 修复取件码输入框的响应式数据流问题

### DIFF
--- a/src/components/common/RetrieveForm.vue
+++ b/src/components/common/RetrieveForm.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, watch } from 'vue'
+import { ref, inject, computed } from 'vue'
 import { ArrowRightIcon } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 
@@ -73,24 +73,24 @@ interface InputStatus {
 interface Props {
   inputStatus: InputStatus
   error?: boolean
+  modelValue: string
 }
 
 interface Emits {
   submit: []
-  'update:code': [value: string]
+  'update:modelValue': [value: string]
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 const isDarkMode = inject('isDarkMode')
-const code = ref('')
+const code = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value)
+})
 const isInputFocused = ref(false)
 const codeInput = ref<HTMLInputElement>()
-
-watch(code, (newValue) => {
-  emit('update:code', newValue)
-})
 
 defineExpose({
   focus: () => codeInput.value?.focus()

--- a/src/views/RetrievewFileView.vue
+++ b/src/views/RetrievewFileView.vue
@@ -14,10 +14,10 @@
         <div class="p-8">
           <PageHeader :title="config.name" @title-click="toSend" />
           <RetrieveForm
+            v-model="code"
             :input-status="inputStatus"
             :error="!!error"
             @submit="handleSubmit"
-            @update:code="code = $event"
             ref="retrieveFormRef"
           />
         </div>


### PR DESCRIPTION
## 问题
输入取件码，当取件码不存在或者错误的时候，后台清空绑定的变量，但是前端空间并未清空，就会导致界面明明有输入取件码，但是提交却报错请输入取件码：

<img width="1520" height="1101" alt="1" src="https://github.com/user-attachments/assets/e8498f89-d117-45fc-be7a-d693334f5dd7" />

src/views/RetrievewFileView.vue 第220行

```javascript
finally {
    inputStatus.value.readonly = false
    inputStatus.value.loading = false
    code.value = ''
  }
```
## 分析
 Vue 响应式数据流问题：父与子控件之间的单向数据传输导致的

## 修复
使用 props + v-model